### PR TITLE
AWS上にVPCを構築するmoduleを構築する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ terraform.tfvars
 
 # IDEA setting files
 .idea/
-
+terraform-aws-vpc.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.terraform
+terraform.tfstate
+*.tfstate*
+terraform.tfvars
+
+# IDEA setting files
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # terraform-aws-vpc
 Terraform module to create VPC resource on AWS.
+
+Creates the following resources:
+
+- VPC
+- Subnet
+- Nat Instance
+- Route table
+- Internet Gateway
+- Network ACL
+
+## Usage
+
+```hcl
+module "vpc" {
+  source = "nekochans/vpc/aws"
+
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  nat_instance_ami         = "ami-0af1df87db7b650f4"
+  nat_instance_type        = "t2.micro"
+  nat_instance_volume_type = "gp2"
+  nat_instance_volume_size = "30"
+
+  azs             = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
+  private_subnets = ["10.10.0.0/24", "10.10.1.0/24", "10.10.2.0/24"]
+  public_subnets  = ["10.10.10.0/24", "10.10.11.0/24", "10.10.12.0/24"]
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.24 |
+| aws | ~> 2.56 |
+
+
+## Input
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| name | Name to be used on all the resources as identifier | `string` | `""` | no |
+| env | The target environment | `string` | `""` | no |
+| cidr | The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden | `string` | `"0.0.0.0/0"` | no |
+| nat\_instance\_ami | Amazon Machine Image (AMI) for NAT Instance | `string` | `""` | no |
+| nat\_instance\_type | Instance type for NAT Instance | `string` | `""` | no |
+| nat\_instance\_volume\_type | Volume type for Nat Instance | `string` | `""` | no |
+| nat\_instance\_volume\_size | Volume size for Nat Instance | `string` | `""` | no |
+| azs | A list of availability zones names or ids in the region | `list(string)` | `[]` | no |
+| public\_subnets | A list of public subnets inside the VPC | `list(string)` | `[]` | no |
+| private\_subnets | A list of private subnets inside the VPC | `list(string)` | `[]` | no |
+
+## Output
+
+| Name | Description |
+|------|-------------|
+| vpc\_id | The ID of the VPC |
+| subnet\_public\_ids | List of IDs of public subnets |
+| subnet\_private\_ids | List of IDs of private subnets |

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,417 @@
+######
+# VPC
+######
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr
+  enable_dns_support   = "true"
+  enable_dns_hostnames = "true"
+
+  tags = {
+    Name = "${var.env}-${var.name}-vpc"
+  }
+}
+
+######
+# Internet Gateway
+######
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.env}-${var.name}-igw"
+  }
+}
+
+################
+# Nat instance
+################
+resource "aws_security_group" "nat_instance" {
+  name        = "${var.env}-${var.name}-nat"
+  description = "${var.env}-${var.name}-nat"
+  vpc_id      = aws_vpc.this.id
+
+  tags = {
+    Name = "${var.env}-${var.name}-nat"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "http_from_vpc_to_nat_instance" {
+  security_group_id = aws_security_group.nat_instance.id
+  type              = "ingress"
+  from_port         = "80"
+  to_port           = "80"
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.this.cidr_block]
+}
+
+resource "aws_security_group_rule" "https_from_vpc_to_nat_instance" {
+  security_group_id = aws_security_group.nat_instance.id
+  type              = "ingress"
+  from_port         = "443"
+  to_port           = "443"
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.this.cidr_block]
+}
+
+data "aws_iam_policy_document" "nat_instance_trust_relationship" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "nat_instance_role" {
+  name               = "${var.env}-${var.name}-nat-instance-default-role"
+  assume_role_policy = data.aws_iam_policy_document.nat_instance_trust_relationship.json
+}
+
+resource "aws_iam_role_policy_attachment" "attachment_amazon_ec2_role_for_ssm" {
+  role       = aws_iam_role.nat_instance_role.id
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+resource "aws_iam_instance_profile" "nat_instance_profile" {
+  name = "${var.env}-${var.name}-nat-instance-profile"
+  role = aws_iam_role.nat_instance_role.name
+}
+
+resource "aws_instance" "nat_instance" {
+  ami                         = var.nat_instance_ami
+  associate_public_ip_address = true
+  instance_type               = var.nat_instance_type
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_type = var.nat_instance_volume_type
+    volume_size = var.nat_instance_volume_size
+  }
+
+  subnet_id              = aws_subnet.public[length(var.azs) - 1].id
+  vpc_security_group_ids = [aws_security_group.nat_instance.id]
+
+  tags = {
+    "Name" = format(
+      "${var.env}-${var.name}-nat-%s",
+      element(var.azs, length(var.azs) - 1),
+    )
+  }
+
+  iam_instance_profile = aws_iam_instance_profile.nat_instance_profile.name
+  monitoring           = true
+  source_dest_check    = false
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+################
+# Publiс routes
+################
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = "${var.env}-${var.name}-public-rt"
+  }
+}
+
+##########################
+# Private routes
+##########################
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block  = "0.0.0.0/0"
+    instance_id = aws_instance.nat_instance.id
+  }
+
+  tags = {
+    Name = "${var.env}-${var.name}-private-rt"
+  }
+}
+
+################
+# Public subnet
+################
+resource "aws_subnet" "public" {
+  count = length(var.public_subnets)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = element(concat(var.public_subnets, [""]), count.index)
+  availability_zone = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
+
+  tags = {
+    "Name" = format(
+      "${var.env}-${var.name}-public-%s",
+      element(var.azs, count.index),
+    )
+  }
+}
+
+#################
+# Private subnet
+#################
+resource "aws_subnet" "private" {
+  count = length(var.public_subnets)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = element(concat(var.private_subnets, [""]), count.index)
+  availability_zone = length(regexall("^[a-z]{2}-", element(var.azs, count.index))) > 0 ? element(var.azs, count.index) : null
+
+  tags = {
+    "Name" = format(
+      "${var.env}-${var.name}-private-%s",
+      element(var.azs, count.index),
+    )
+  }
+}
+
+##########################
+# Route table association
+##########################
+
+resource "aws_route_table_association" "public" {
+  count = length(var.public_subnets) > 0 ? length(var.public_subnets) : 0
+
+  subnet_id = element(aws_subnet.public.*.id, count.index)
+  route_table_id = element(
+    aws_route_table.public.*.id,
+    count.index,
+  )
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
+
+  subnet_id = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(
+    aws_route_table.private.*.id,
+    count.index,
+  )
+}
+
+########################
+# Public Network ACLs
+########################
+resource "aws_network_acl" "public" {
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 22
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 3389
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 3389
+    cidr_block = aws_vpc.this.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 140
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 3306
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 3306
+    cidr_block = aws_vpc.this.cidr_block
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 140
+    to_port    = 22
+    cidr_block = "0.0.0.0/0"
+  }
+
+  subnet_ids = aws_subnet.public.*.id
+
+  tags = {
+    Name = "${var.env}-${var.name}-public"
+  }
+}
+
+#######################
+# Private Network ACLs
+#######################
+resource "aws_network_acl" "private" {
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = aws_vpc.this.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = aws_vpc.this.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 22
+    cidr_block = aws_vpc.this.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 3306
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 3306
+    cidr_block = aws_vpc.this.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 3389
+    protocol   = "tcp"
+    rule_no    = 140
+    to_port    = 3389
+    cidr_block = aws_vpc.this.cidr_block
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 150
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 22
+    cidr_block = "0.0.0.0/0"
+  }
+
+  subnet_ids = aws_subnet.private.*.id
+
+  tags = {
+    Name = "${var.env}-${var.name}-private"
+  }
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  value       = aws_vpc.this.id
+  description = "The ID of the VPC"
+}
+
+output "subnet_public_ids" {
+  value       = aws_subnet.public.*.id
+  description = "List of IDs of public subnets"
+}
+
+output "subnet_private_ids" {
+  value       = aws_subnet.private.*.id
+  description = "List of IDs of private subnets"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,60 @@
+variable "name" {
+  description = "Name to be used on all the resources as identifier"
+  type        = string
+  default     = ""
+}
+
+variable "env" {
+  description = "The target environment"
+  type        = string
+  default     = ""
+}
+
+variable "cidr" {
+  description = "The CIDR block for the VPC. Default value is a valid CIDR, but not acceptable by AWS and should be overridden"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "nat_instance_ami" {
+  description = "Amazon Machine Image (AMI) for NAT Instance"
+  type        = string
+  default     = ""
+}
+
+variable "nat_instance_type" {
+  description = "Instance type for NAT Instance"
+  type        = string
+  default     = ""
+}
+
+
+variable "nat_instance_volume_type" {
+  description = "Volume type for Nat Instance"
+  type        = string
+  default     = ""
+}
+
+variable "nat_instance_volume_size" {
+  description = "Volume size for Nat Instance"
+  type        = string
+  default     = ""
+}
+
+variable "azs" {
+  description = "A list of availability zones names or ids in the region"
+  type        = list(string)
+  default     = []
+}
+
+variable "public_subnets" {
+  description = "A list of public subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnets" {
+  description = "A list of private subnets inside the VPC"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,6 @@ variable "nat_instance_type" {
   default     = ""
 }
 
-
 variable "nat_instance_volume_type" {
   description = "Volume type for Nat Instance"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.24"
+
+  required_providers {
+    aws = "~> 2.56"
+  }
+}


### PR DESCRIPTION
## 変更点概要
- AWS上にVPCを構築するmoduleを作成
- READMEにmoduleの説明、使用方法を記載

下記moduleを参考に構築した。
https://github.com/terraform-aws-modules/terraform-aws-vpc

## 補足
Terraform Registryへの公開方法は下記を参照した。
https://www.terraform.io/docs/registry/modules/publish.html

また、下記については別のPRで対応する。
- VPC Flow Logの追加
- moduleの利用例を`examples`配下のディレクトリに追加する

## ドキュメントについて
READMEは今回は手動で作成したが、下記のツールを使用することで自動で生成ができる。
https://github.com/segmentio/terraform-docs

`examples`にサンプルを追加した後は、`terraform-docs`で自動生成する想定。

