### PR TITLE
Terraform0.13に対応

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = "~> 0.12.24"
+  required_version = ">= 0.13.0, < 0.14"
 
   required_providers {
-    aws = "~> 2.56"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.56"
+    }
   }
 }


### PR DESCRIPTION
## 変更点
Terraform 0.13に対応するためrequired_versionを変更。
0.13にアップグレートするため、providerの指定方法も変更している。