### PR TITLE
Terraform0.14に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module "vpc" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0, < 0.14 |
+| terraform | >= 0.14.0, < 0.15 |
 | aws | ~> 2.56 |
 
 ## Providers

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0, < 0.14"
+  required_version = ">= 0.14.0, < 0.15"
 
   required_providers {
     aws = {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/terraform-aws-vpc/issues/13

# やった事
https://github.com/nekochans/terraform-aws-vpc/issues/13 に書いてある通り Terraform0.14 に対応するPR。

※ aws providerのバージョンもそのうち上げたい。